### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@
 fixtures:
   repositories:
     common: "git://github.com/simp/pupmod-simp-common.git"
+    simplib: 'git://github.com/simp/pupmod-simp-simplib'
     stdlib: "git://github.com/simp/puppetlabs-stdlib.git"
   symlinks:
     activemq: "#{source_dir}"

--- a/build/pupmod-simp-activemq.spec
+++ b/build/pupmod-simp-activemq.spec
@@ -3,7 +3,7 @@
 Summary:  SIMP ActiveMQ Puppet Module
 Name: pupmod-simp-activemq
 Version: 2.0.0
-Release: 0
+Release: 1
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -49,6 +49,9 @@ done
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 2.0.0-1
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.0-0
 - Changed puppet-server requirement to puppet
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-activemq`.
SIMP-604 #comment Updated `pupmod-simp-activemq`.